### PR TITLE
Updates inputs onchange logic

### DIFF
--- a/src/pages/EditProfilePage.js
+++ b/src/pages/EditProfilePage.js
@@ -155,6 +155,10 @@ const EditProfilePage = () => {
     }
   };
 
+  const isProfileOwner = () => {
+    return user._id === userId;
+  };
+
   const handleSubmit = async (e) => {
     e.preventDefault();
 
@@ -242,7 +246,7 @@ const EditProfilePage = () => {
                 fullWidth
                 required
                 sx={editProfileClasses.nameField}
-                onChange={(e) => user._id === userId && setUsername(e.target.value)}
+                onChange={(e) => isProfileOwner() && setUsername(e.target.value)}
                 error={usernameError}
                 value={username}
                 disabled={disabledInput}
@@ -255,7 +259,7 @@ const EditProfilePage = () => {
                 fullWidth
                 required
                 sx={editProfileClasses.nameField}
-                onChange={(e) => user._id === userId && setEmail(e.target.value)}
+                onChange={(e) => isProfileOwner() && setEmail(e.target.value)}
                 error={emailError}
                 value={email}
                 disabled={disabledInput}
@@ -267,13 +271,13 @@ const EditProfilePage = () => {
                 variant='outlined'
                 fullWidth
                 sx={editProfileClasses.nameField}
-                onChange={user._id === userId && validateContact}
+                onChange={isProfileOwner() && validateContact}
                 value={contact}
                 disabled={disabledInput}
                 placeholder='912345678'
               />
 
-              {user._id === userId && (
+              {isProfileOwner() && (
                 <>
                   <TextField
                     label='Nova Password'
@@ -377,7 +381,7 @@ const EditProfilePage = () => {
               </Button>
             )}
             <>
-              {user._id === userId && (
+              {isProfileOwner() && (
                 <Button sx={{ mr: 1, mt: { xs: 1, sm: 0 } }} type='button' variant='outlined' endIcon={<AddIcon />} onClick={() => inputFileUpload.current.click()}>
                   Imagem
                 </Button>

--- a/src/pages/EditProfilePage.js
+++ b/src/pages/EditProfilePage.js
@@ -9,7 +9,6 @@ import { deleteShopUser, updateShopUser } from '../redux/features/users/usersSli
 
 import convert from 'image-file-resize';
 
-import * as React from 'react';
 import { Box, Button, CircularProgress, TextField, Typography } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import Modal from '@mui/material/Modal';
@@ -54,7 +53,7 @@ const EditProfilePage = () => {
   const { userId } = useParams();
   const navigate = useNavigate();
 
-  const [open, setOpen] = React.useState(false);
+  const [open, setOpen] = useState(false);
   const handleOpen = () => setOpen(true);
   const handleClose = () => setOpen(false);
 
@@ -243,7 +242,7 @@ const EditProfilePage = () => {
                 fullWidth
                 required
                 sx={editProfileClasses.nameField}
-                onChange={(e) => setUsername(e.target.value)}
+                onChange={(e) => user._id === userId && setUsername(e.target.value)}
                 error={usernameError}
                 value={username}
                 disabled={disabledInput}
@@ -256,7 +255,7 @@ const EditProfilePage = () => {
                 fullWidth
                 required
                 sx={editProfileClasses.nameField}
-                onChange={(e) => setEmail(e.target.value)}
+                onChange={(e) => user._id === userId && setEmail(e.target.value)}
                 error={emailError}
                 value={email}
                 disabled={disabledInput}
@@ -268,37 +267,41 @@ const EditProfilePage = () => {
                 variant='outlined'
                 fullWidth
                 sx={editProfileClasses.nameField}
-                onChange={validateContact}
+                onChange={user._id === userId && validateContact}
                 value={contact}
                 disabled={disabledInput}
                 placeholder='912345678'
               />
 
-              <TextField
-                label='Nova Password'
-                type='password'
-                variant='outlined'
-                fullWidth
-                sx={editProfileClasses.nameField}
-                onChange={(e) => setNewPassword(e.target.value)}
-                error={passwordError}
-                value={newPassword}
-                disabled={disabledInput}
-                placeholder='********'
-              />
+              {user._id === userId && (
+                <>
+                  <TextField
+                    label='Nova Password'
+                    type='password'
+                    variant='outlined'
+                    fullWidth
+                    sx={editProfileClasses.nameField}
+                    onChange={(e) => setNewPassword(e.target.value)}
+                    error={passwordError}
+                    value={newPassword}
+                    disabled={disabledInput}
+                    placeholder='********'
+                  />
 
-              <TextField
-                label='Repetir Password'
-                type='password'
-                variant='outlined'
-                fullWidth
-                sx={editProfileClasses.nameField}
-                onChange={(e) => setNewPassword2(e.target.value)}
-                error={passwordError}
-                value={newPassword2}
-                disabled={disabledInput}
-                placeholder='********'
-              />
+                  <TextField
+                    label='Repetir Password'
+                    type='password'
+                    variant='outlined'
+                    fullWidth
+                    sx={editProfileClasses.nameField}
+                    onChange={(e) => setNewPassword2(e.target.value)}
+                    error={passwordError}
+                    value={newPassword2}
+                    disabled={disabledInput}
+                    placeholder='********'
+                  />
+                </>
+              )}
 
               {user.userType === 'admin' && (
                 <TextField


### PR DESCRIPTION
**PR description**

- Prevents anyone else beside the profile owner to change the state of the input fields, by checking the `id` of the current user and the id of the profile owner.

**How to replicate the issue**

1. Once logged in, click the `Utilizadores` tab in the navbar
2. Click in one of the users 
3. Click the button `Editar`
4. Go to `inspect` in your browser
5. Find the input element in the `Elements` tab of the `inspect`
6. Delete the Disabled property
7. Edit the input as you normally would
8. Click `Actualizar`

<img width="1439" alt="Screenshot 2023-03-03 at 18 50 00" src="https://user-images.githubusercontent.com/69796068/222805113-7708d64e-5c2d-4c01-8cde-9ac770fb2e47.png">
