### PR TITLE
Feat: add tilt animation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "react-dom": "^18.2.0",
         "react-error-boundary": "^3.1.4",
         "react-masonry-css": "^1.0.16",
+        "react-parallax-tilt": "^1.7.112",
         "react-redux": "^8.0.2",
         "react-router-dom": "^6.3.0",
         "react-scripts": "5.0.1",
@@ -15366,6 +15367,15 @@
         "react": ">=16.0.0"
       }
     },
+    "node_modules/react-parallax-tilt": {
+      "version": "1.7.112",
+      "resolved": "https://registry.npmjs.org/react-parallax-tilt/-/react-parallax-tilt-1.7.112.tgz",
+      "integrity": "sha512-W8WhEpEjn09CwDj3opOg0sRyRsR4B6C6xONhsBgOXKFgtA8LKN7NgcwAOq14gKJaLHKRxiO418pC8P4VTIq2/w==",
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-redux": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.0.2.tgz",
@@ -29197,6 +29207,12 @@
       "version": "1.0.16",
       "resolved": "https://registry.npmjs.org/react-masonry-css/-/react-masonry-css-1.0.16.tgz",
       "integrity": "sha512-KSW0hR2VQmltt/qAa3eXOctQDyOu7+ZBevtKgpNDSzT7k5LA/0XntNa9z9HKCdz3QlxmJHglTZ18e4sX4V8zZQ==",
+      "requires": {}
+    },
+    "react-parallax-tilt": {
+      "version": "1.7.112",
+      "resolved": "https://registry.npmjs.org/react-parallax-tilt/-/react-parallax-tilt-1.7.112.tgz",
+      "integrity": "sha512-W8WhEpEjn09CwDj3opOg0sRyRsR4B6C6xONhsBgOXKFgtA8LKN7NgcwAOq14gKJaLHKRxiO418pC8P4VTIq2/w==",
       "requires": {}
     },
     "react-redux": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react-dom": "^18.2.0",
     "react-error-boundary": "^3.1.4",
     "react-masonry-css": "^1.0.16",
+    "react-parallax-tilt": "^1.7.112",
     "react-redux": "^8.0.2",
     "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.1",

--- a/src/pages/AboutPage.js
+++ b/src/pages/AboutPage.js
@@ -1,5 +1,6 @@
 // jshint esversion:9
 
+import Tilt from 'react-parallax-tilt';
 import { capitalizeAppName, appEmail, ownerName } from '../utils/app.utils.js';
 import mapImage from '../images/aboutMap.png';
 import ownerImage from '../images/aboutChef.jpeg';
@@ -113,8 +114,10 @@ const AboutPage = () => {
   return (
     <Box sx={aboutClasses.container}>
       <Grid container spacing={0} sx={aboutClasses.hero}>
-        <Grid item xs={12} md={6} sx={{ display: { lg: 'flex' }, justifyContent: { lg: 'end' } }}>
+        <Grid item xs={12} md={6} sx={{ display: { lg: 'flex' }, justifyContent: { lg: 'center' } }}>
+        <Tilt>
           <Box sx={aboutClasses.imgContainer}></Box>
+          </Tilt>
         </Grid>
         <Grid item xs={12} md={6} sx={{ display: { lg: 'flex' }, justifyContent: { lg: 'start' } }}>
           <Box sx={aboutClasses.heroText}>


### PR DESCRIPTION
This PR adds tilt animation to the avatar image on about page. It was used [react-parallax-tilt](https://www.npmjs.com/package/react-parallax-tilt) to animate the image container. You have to hover the image to check the animation. The code was also tested on mobile
<img width="1389" alt="image" src="https://user-images.githubusercontent.com/59636753/224200554-44616ec7-015b-42f2-a2c8-ce19ff70225d.png">
