### PR TITLE
Update redux extraReducers

### DIFF
--- a/src/redux/features/items/itemsSlice.js
+++ b/src/redux/features/items/itemsSlice.js
@@ -114,18 +114,18 @@ const itemsSlice = createSlice({
       //console.log('current shop items in updateShopItem   =>', current(state).shopItems);
     },
   },
-  extraReducers: {
-    [getShopItems.pending]: (state) => {
-      state.isLoading = true;
-    },
-    [getShopItems.fulfilled]: (state, action) => {
-      //console.log('action on fulfilled', action);
-      state.isLoading = false;
-      state.shopItems = action.payload;
-    },
-    [getShopItems.rejected]: (state) => {
-      state.isLoading = false;
-    },
+  extraReducers: (builder) => {
+    builder
+      .addCase(getShopItems.pending, (state) => {
+        state.isLoading = true;
+      })
+      .addCase(getShopItems.fulfilled, (state, action) => {
+        state.isLoading = false;
+        state.shopItems = action.payload;
+      })
+      .addCase(getShopItems.rejected, (state) => {
+        state.isLoading = false;
+      });
   },
 });
 

--- a/src/redux/features/orders/ordersSlice.js
+++ b/src/redux/features/orders/ordersSlice.js
@@ -1,5 +1,6 @@
 // jshint esversion:9
 
+// eslint-disable-next-line no-unused-vars
 import { createSlice, createAsyncThunk, current } from '@reduxjs/toolkit';
 import { getAllOrders } from '../../../api';
 
@@ -59,18 +60,18 @@ const ordersSlice = createSlice({
       //console.log('current shop orders in updateShopOrder   =>', current(state).shopOrders);
     },
   },
-  extraReducers: {
-    [getShopOrders.pending]: (state) => {
-      state.isLoading = true;
-    },
-    [getShopOrders.fulfilled]: (state, action) => {
-      //console.log('action on fulfilled', action);
-      state.isLoading = false;
-      state.shopOrders = action.payload;
-    },
-    [getShopOrders.rejected]: (state) => {
-      state.isLoading = false;
-    },
+  extraReducers: (builder) => {
+    builder
+      .addCase(getShopOrders.pending, (state) => {
+        state.isLoading = true;
+      })
+      .addCase(getShopOrders.fulfilled, (state, action) => {
+        state.isLoading = false;
+        state.shopOrders = action.payload;
+      })
+      .addCase(getShopOrders.rejected, (state) => {
+        state.isLoading = false;
+      });
   },
 });
 

--- a/src/redux/features/users/usersSlice.js
+++ b/src/redux/features/users/usersSlice.js
@@ -1,5 +1,6 @@
 // jshint esversion:9
 
+// eslint-disable-next-line no-unused-vars
 import { createSlice, createAsyncThunk, current } from '@reduxjs/toolkit';
 import { getAllUsers } from '../../../api';
 
@@ -37,18 +38,18 @@ const usersSlice = createSlice({
       state.shopUsers.push(payload);
     },
   },
-  extraReducers: {
-    [getShopUsers.pending]: (state) => {
-      state.isLoading = true;
-    },
-    [getShopUsers.fulfilled]: (state, action) => {
-      //console.log('action on fulfilled', action);
-      state.isLoading = false;
-      state.shopUsers = action.payload;
-    },
-    [getShopUsers.rejected]: (state) => {
-      state.isLoading = false;
-    },
+  extraReducers: (builder) => {
+    builder
+      .addCase(getShopUsers.pending, (state) => {
+        state.isLoading = true;
+      })
+      .addCase(getShopUsers.fulfilled, (state, action) => {
+        state.isLoading = false;
+        state.shopUsers = action.payload;
+      })
+      .addCase(getShopUsers.rejected, (state) => {
+        state.isLoading = false;
+      });
   },
 });
 


### PR DESCRIPTION
**PR description**
- Updates redux extraReducers to use builder callback notation instead of object notation since it will not work in future version of redux

**Whatis extraReducers ?**

Overall, the extraReducers field allows you to define additional reducers that can respond to any action dispatched by your Redux store, making it easier to manage your app's state in response to asynchronous events.

**Description of Items `extraReducers`**

There are three reducers added to the builder object:

- getShopItems.pending: This reducer is triggered when the getShopItems action is dispatched with a status of "pending". It sets the isLoading state to true, which indicates that the app is currently loading the shop items.

- getShopItems.fulfilled: This reducer is triggered when the getShopItems action is dispatched with a status of "fulfilled", which means that the shop items have been successfully loaded. It sets the isLoading state to false and updates the shopItems state with the data returned by the action.

- getShopItems.rejected: This reducer is triggered when the getShopItems action is dispatched with a status of "rejected", which means that an error occurred while loading the shop items. It sets the isLoading state to false, indicating that the loading process has stopped.